### PR TITLE
+faster C code  +Rust

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,9 +4,12 @@
 !*.c
 !*.py
 !*.rb
+!*.rs
 !*.sh
 !*.md
 !*.MD
 !*.java
 !.gitignore
 proc_speed_test_C
+proc_speed_test_C2
+proc_speed_test_Rust

--- a/measure.sh
+++ b/measure.sh
@@ -1,5 +1,20 @@
 #!/bin/bash
 
+# Fordítások
+
+CFILE=proc_speed_test_C
+gcc -O2 -Wall $CFILE.c -o $CFILE
+
+CFILE=proc_speed_test_C2
+gcc -O2 -Wall $CFILE.c -o $CFILE
+
+javac Proc_Speed_Test.java
+
+rustc -O proc_speed_test_Rust.rs
+
+# Fordítások vége
+# Futtatások
+
 # a time format azért ilyen, hogy az '=' kezdetű sorokat közvetlenül .csv-be tudjam menteni,
 # amit aztán egy LibreOffice fel tud dolgozni
 alias tm='/usr/bin/time -f "= \"%C\";%e;%S;%U;%I;%O;%c"'
@@ -25,6 +40,12 @@ tm perl ./proc_speed_test.pl
 
 echo -e "\nC"
 tm ./proc_speed_test_C
+
+echo -e "\nC"
+tm ./proc_speed_test_C2
+
+echo -e "\nC"
+tm ./proc_speed_test_Rust
 
 echo -e "\nLUA"
 tm luajit ./proc_speed_test.lua

--- a/proc_speed_test_C2.c
+++ b/proc_speed_test_C2.c
@@ -1,0 +1,39 @@
+#include <stdio.h>
+#include <unistd.h>
+#include <string.h>
+#include <sys/types.h>
+#include <dirent.h>
+
+int main () {
+    unsigned int errctr=0 ,ctr=0;
+    char buff[10000];
+
+    DIR *dp;
+    struct dirent *ep;
+
+    for(int j=0; j<10000; j++) {
+	if ((dp = opendir ("/proc"))) {
+	    while ((ep = readdir (dp))) {
+		FILE *f;
+		if (ep->d_name[0] > '9' || ep->d_name[0] < '0') continue; // nem számozott mappa
+		char fname[1000] = "/proc/";
+		strcat(fname, ep->d_name);
+		strcat(fname, "/stat");
+		if ((f=fopen(fname, "r"))) {
+		    if (!fgets(buff, sizeof(buff), f)) {
+			fprintf(stderr, "Coundn't read from file: %s\n", fname);
+		    }
+		    fclose(f);
+		    ctr++;
+		} else {
+		    fprintf(stderr, "Couldn't open file: %s\n", fname);
+		    errctr++;
+		}
+	    }
+	    (void) closedir (dp);
+	} else perror ("Couldn't open the directory");
+    }
+    printf("Count: %u\n",ctr);
+    printf("Error Count: %u\n",errctr);
+    return 0;
+}

--- a/proc_speed_test_Rust.rs
+++ b/proc_speed_test_Rust.rs
@@ -1,0 +1,32 @@
+use std::fs;
+use std::io::BufReader;
+use std::io::BufRead;
+use std::fs::File;
+
+
+fn main() {
+    let mut cnt=0;
+    let mut errcnt=0;
+    for _i in 0..10000 {
+	if let Ok(entries) = fs::read_dir("/proc") {
+	    for entry in entries {
+		if let Ok(entry) = entry {
+		    let fname = entry.file_name().into_string().unwrap();
+		    if fname.parse::<i32>().is_ok() {
+			if let Ok(file) = File::open("/proc/".to_owned()+&fname+"/stat") {
+			    let mut reader = BufReader::new(file);
+			    let mut line = String::new();
+			    let _len = reader.read_line(&mut line).unwrap();
+			    //println!("-> {}, {}", len, line);
+			    cnt += 1;
+			} else {
+			    errcnt += 1;
+			}
+		    }
+		}
+	    }
+	}
+    }
+    println!("Count: {}", cnt);
+    println!("Error count: {}", errcnt);
+}


### PR DESCRIPTION
+_C2.c   +Rust
+ fordítás a measure.sh szkriptben + C2 + Rust

Megjegyzés:

time ./proc_speed_test_C2

real 0m20,167s
user 0m2,818s   <---- programozási nyelv futási ideje
sys 0m17,079s   < --- kernel "nyaggatás" ideje

$ time pypy proc_speed_test.py

real 0m32,157s
user 0m9,461s
sys 0m22,287s

Ebből az látszik, hogy a kernelhívás visz el sok időt, maga a progam futásideje kevésbé jelentős. Egyébként az Intel Meltdown hibájának a javítása a sok kernelhívás miatt sokat rontott ezen a teszten.